### PR TITLE
[#6] Integrate deeper with Tauri, set up menu options and messaging

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["chakra", "quicktime", "tauri"]
+  "cSpell.words": ["chakra", "Fullscreen", "quicktime", "tauri"]
 }

--- a/README.md
+++ b/README.md
@@ -32,12 +32,19 @@ Will build with vite and with tauri:
 npm run test-build
 ```
 
+To actuall build for "production":
+
+```bash
+npm run tauri build
+```
+
 ## Stack
 
 Leverages some of these libraries:
 
 - [Chakra](https://v2.chakra-ui.com/docs/components)
 - [Tauri](https://tauri.app/v1/guides/)
+- [Tauri config](https://tauri.app/v1/api/config#configuration-structure)
 
 Tauri was integrated after the fact. For more information on the Rust components, see [the docs](https://tauri.app/v1/guides/getting-started/setup/integrate).
 

--- a/src/src-tauri/Cargo.lock
+++ b/src/src-tauri/Cargo.lock
@@ -1408,10 +1408,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "libappindicator"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2d3cb96d092b4824cb306c9e544c856a4cb6210c1081945187f7f1924b47e8"
+dependencies = [
+ "glib",
+ "gtk",
+ "gtk-sys",
+ "libappindicator-sys",
+ "log",
+]
+
+[[package]]
+name = "libappindicator-sys"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b3b6681973cea8cc3bce7391e6d7d5502720b80a581c9a95c9cbaf592826aa"
+dependencies = [
+ "gtk-sys",
+ "libloading",
+ "once_cell",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
 
 [[package]]
 name = "libredox"
@@ -2545,6 +2579,7 @@ dependencies = [
  "core-foundation",
  "core-graphics",
  "crossbeam-channel",
+ "dirs-next",
  "dispatch",
  "gdk",
  "gdk-pixbuf",
@@ -2559,6 +2594,7 @@ dependencies = [
  "instant",
  "jni",
  "lazy_static",
+ "libappindicator",
  "libc",
  "log",
  "ndk",

--- a/src/src-tauri/Cargo.toml
+++ b/src/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "1.5.2", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.6.5", features = [] }
+tauri = { version = "1.6.5", features = [ "global-shortcut-all", "window-set-fullscreen", "system-tray"] }
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.

--- a/src/src-tauri/src/main.rs
+++ b/src/src-tauri/src/main.rs
@@ -3,6 +3,11 @@
 
 use tauri::{ Menu, MenuItem, Submenu };
 
+#[tauri::command]
+fn console_print(message: String) {
+	println!("Message received: {message}");
+}
+
 fn main() {
 	let file_menu = Submenu::new("File", Menu::new()
 		.add_native_item(MenuItem::CloseWindow)
@@ -26,6 +31,7 @@ fn main() {
 
   tauri::Builder::default()
 		.menu(menu)
+		.invoke_handler(tauri::generate_handler!(console_print))
     .run(tauri::generate_context!())
     .expect("error while running tauri application");
 }

--- a/src/src-tauri/tauri.conf.json
+++ b/src/src-tauri/tauri.conf.json
@@ -16,6 +16,9 @@
       "window": {
         "all": false,
         "setFullscreen": true
+      },
+      "globalShortcut": {
+        "all": true
       }
     },
     "bundle": {
@@ -64,10 +67,10 @@
     "windows": [
       {
         "fullscreen": false,
-        "height": 600,
+        "height": 768,
         "resizable": true,
         "title": "Perugia View",
-        "width": 800
+        "width": 1024
       }
     ]
   }

--- a/src/src-tauri/tauri.conf.json
+++ b/src/src-tauri/tauri.conf.json
@@ -12,7 +12,11 @@
   },
   "tauri": {
     "allowlist": {
-      "all": false
+      "all": false,
+      "window": {
+        "all": false,
+        "setFullscreen": true
+      }
     },
     "bundle": {
       "active": true,
@@ -46,6 +50,10 @@
         "digestAlgorithm": "sha256",
         "timestampUrl": ""
       }
+    },
+    "systemTray": {
+      "iconPath": "icons/icon.png",
+      "iconAsTemplate": true
     },
     "security": {
       "csp": null

--- a/src/src/App.tsx
+++ b/src/src/App.tsx
@@ -6,9 +6,15 @@ import Notice from './components/common/Notice';
 import useUIStateContext from './hooks/useUiStateContext';
 import { Views } from './utils/constants';
 import Show from './components/Show/Show';
+import { useEffect } from 'react';
+import tauriPrint from './utils/tauriPrint';
 
 function App() {
   const { view } = useUIStateContext();
+
+  useEffect(() => {
+    tauriPrint('React mounted.');
+  }, []);
 
   return (
     <Box h="100%" w="100%" display="flex" overflow="hidden">

--- a/src/src/App.tsx
+++ b/src/src/App.tsx
@@ -7,13 +7,13 @@ import useUIStateContext from './hooks/useUiStateContext';
 import { Views } from './utils/constants';
 import Show from './components/Show/Show';
 import { useEffect } from 'react';
-import tauriPrint from './utils/tauriPrint';
+import { tauriPrintDebounced } from './utils/tauriAdapter';
 
 function App() {
   const { view } = useUIStateContext();
 
   useEffect(() => {
-    tauriPrint('React mounted.');
+    tauriPrintDebounced('React mounted.');
   }, []);
 
   return (

--- a/src/src/components/Show/Show.tsx
+++ b/src/src/components/Show/Show.tsx
@@ -9,7 +9,7 @@ import ControlBar from './ControlBar';
 import eventBus, {
   DriverActionEnum,
   DriverEventEnum,
-} from 'src/utils/eventBus';
+} from 'src/utils/events/driver';
 import useToggleState from 'src/hooks/useToggleState';
 import { CACHE_AMOUNT, CONTROL_HIDE_DELAY } from 'src/utils/constants';
 

--- a/src/src/providers/SettingsProvider.tsx
+++ b/src/src/providers/SettingsProvider.tsx
@@ -2,6 +2,9 @@ import React, { createContext, useCallback, useEffect, useState } from 'react';
 import SettingsModal from 'src/components/Settings/SettingsModal';
 import Driver from 'src/utils/Driver';
 import { DEFAULT_SLIDE_ADVANCE_TIME } from 'src/utils/constants';
+import generalEventBus, {
+  TauriLinkEventMessage,
+} from 'src/utils/events/general';
 
 interface SettingsContextValues {
   advanceTime: number;
@@ -31,6 +34,20 @@ const SettingsProvider: React.FC<React.PropsWithChildren<ProviderProps>> = ({
     },
     []
   );
+
+  useEffect(() => {
+    const sub = generalEventBus.subscribe((e) => {
+      switch (e.message) {
+        case TauriLinkEventMessage.settings:
+          setIsSettingsModalOpen(true);
+          console.log('Openo');
+          break;
+        default:
+      }
+    });
+
+    return () => sub.unsubscribe();
+  }, []);
 
   useEffect(() => {
     Driver.setAdvanceInterval(advanceTime);

--- a/src/src/utils/Driver.ts
+++ b/src/src/utils/Driver.ts
@@ -3,7 +3,7 @@ import eventBus, {
   DriverAction,
   DriverActionEnum,
   DriverEventEnum,
-} from './eventBus';
+} from './events/driver';
 
 /**
  * Using event based system to decouple driving the slides

--- a/src/src/utils/events/driver.ts
+++ b/src/src/utils/events/driver.ts
@@ -1,8 +1,8 @@
 import { Subject } from 'rxjs';
 
-const eventBus = new Subject<DriverEvent | DriverAction>();
+const driverEventBus = new Subject<DriverEvent | DriverAction>();
 
-export default eventBus;
+export default driverEventBus;
 
 /** Events the Driver should listen to */
 export enum DriverEventEnum {

--- a/src/src/utils/events/general.ts
+++ b/src/src/utils/events/general.ts
@@ -1,0 +1,14 @@
+import { Subject } from 'rxjs';
+
+const generalEventBus = new Subject<TauriLinkEvent>();
+
+export default generalEventBus;
+
+export enum TauriLinkEventMessage {
+  /** A request to open the settings dialogue */
+  settings = 'settings',
+}
+
+export type TauriLinkEvent = {
+  message: TauriLinkEventMessage;
+};

--- a/src/src/utils/tauriAdapter.ts
+++ b/src/src/utils/tauriAdapter.ts
@@ -1,0 +1,37 @@
+import { invoke } from '@tauri-apps/api/tauri';
+import { window as apiWindow, event } from '@tauri-apps/api';
+import debounce from 'lodash/debounce';
+import generalEventBus, { TauriLinkEventMessage } from './events/general';
+
+/** Sends a message to print into Tauri's console */
+export const tauriPrint = (message: string) =>
+  invoke('console_print', { message });
+
+export const tauriPrintDebounced = debounce(tauriPrint, 500, {
+  leading: true,
+  trailing: false,
+});
+
+export const fullscreen = {
+  set: (fullscreen: boolean): Promise<void> =>
+    apiWindow.appWindow.setFullscreen(fullscreen),
+  isOn: () => apiWindow.appWindow.isFullscreen(),
+};
+
+type Payload = {
+  message: TauriLinkEventMessage;
+};
+
+/** Listen to custom events from the Rust wrapper layer */
+const attachEventListeners = async () => {
+  const menuUnSub = await event.listen<Payload>('menu_event', (e) => {
+    generalEventBus.next({ message: e.payload.message });
+  });
+
+  const listenerUnSub = await event.listen('tauri://destroyed', () => {
+    menuUnSub();
+    listenerUnSub();
+  });
+};
+
+void attachEventListeners();

--- a/src/src/utils/tauriPrint.ts
+++ b/src/src/utils/tauriPrint.ts
@@ -1,9 +1,0 @@
-import { invoke } from '@tauri-apps/api/tauri';
-// import { window as appWindow } from '@tauri-apps/api'
-
-/** Sends a message to print into Tauri's console */
-const tauriPrint = (message: string) => invoke('console_print', { message });
-
-// appWindow.appWindow.setFullscreen(true);
-
-export default tauriPrint;

--- a/src/src/utils/tauriPrint.ts
+++ b/src/src/utils/tauriPrint.ts
@@ -1,0 +1,9 @@
+import { invoke } from '@tauri-apps/api/tauri';
+// import { window as appWindow } from '@tauri-apps/api'
+
+/** Sends a message to print into Tauri's console */
+const tauriPrint = (message: string) => invoke('console_print', { message });
+
+// appWindow.appWindow.setFullscreen(true);
+
+export default tauriPrint;


### PR DESCRIPTION
Sets up integration with the Rust backend to perform simple eventing back and forth.

Implements basic menu items, and way for the OS menu to control components inside the app.

Sets up additional eventing layer to enable this.