### PR TITLE
[#11] Basic video handling

### DIFF
--- a/src/src/components/Show/Show.tsx
+++ b/src/src/components/Show/Show.tsx
@@ -138,6 +138,7 @@ export default function Show() {
             key={`slide-${file.originalIndex}`}
             file={file}
             focused={i === CACHE_AMOUNT}
+            playing={toggleStates.playing.isOn}
           />
         ) : null
       )}

--- a/src/src/components/Show/Slide.tsx
+++ b/src/src/components/Show/Slide.tsx
@@ -10,9 +10,10 @@ import Video from '../common/Video';
 type Props = {
   file: EnrichedFile;
   focused?: boolean;
+  playing?: boolean;
 };
 
-export default function Slide({ file, focused }: Props) {
+export default function Slide({ file, focused, playing }: Props) {
   const url = useRef<string | undefined>();
   /** Handle re-render when a slide file updates */
   const [ranKey, setRanKey] = useState(0);
@@ -59,7 +60,12 @@ export default function Slide({ file, focused }: Props) {
       >
         {url.current ? (
           file.mediaType === 'video' ? (
-            <Video src={url.current} autoPlay />
+            <Video
+              src={url.current}
+              autoPlay
+              playing={playing}
+              focused={focused}
+            />
           ) : (
             <Image
               w="100vw"

--- a/src/src/components/common/Video.tsx
+++ b/src/src/components/common/Video.tsx
@@ -1,18 +1,59 @@
+import { useCallback, useEffect, useRef } from 'react';
 import { Box, BoxProps } from '@chakra-ui/react';
 
 type Props = Omit<BoxProps, 'children'> & {
   src: any;
   autoPlay?: boolean;
+  playing?: boolean;
+  focused?: boolean;
 };
 
-export default function Video({ src, autoPlay = false, ...props }: Props) {
+export default function Video({
+  src,
+  autoPlay = false,
+  playing,
+  focused,
+  ...props
+}: Props) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const prevFocused = useRef(false);
+
+  const rewindAndPlay = useCallback(() => {
+    const video = videoRef.current;
+
+    if (!video) return;
+
+    video.currentTime = 0;
+    video.play();
+  }, [videoRef.current]);
+
+  /** Mount and unmount logic */
+  useEffect(() => {
+    if (!playing) return;
+
+    if (focused && !prevFocused.current && playing) {
+      rewindAndPlay();
+      // signal a pause
+    }
+
+    if (!focused && prevFocused.current) {
+      // moving off frame
+      // signal an unpause
+    }
+
+    // start video, listen to finish to pause unpause
+  }, [playing, focused, prevFocused.current, rewindAndPlay]);
+
   return (
     <Box
       src={src}
+      ref={videoRef}
       autoPlay={autoPlay}
       as="video"
       controls
       objectFit="contain"
+      onEnded={() => {}}
+      onPlay={() => {}}
       {...props}
     />
   );

--- a/src/src/utils/Driver.ts
+++ b/src/src/utils/Driver.ts
@@ -50,8 +50,6 @@ class Driver {
   };
 
   public unpause = () => {
-    if (this.paused) return;
-
     this.paused = false;
     this.refresh();
   };
@@ -76,10 +74,12 @@ class Driver {
           else this.stop();
           break;
         case DriverEventEnum.blockingStateChange:
-          if (e.state) {
+          if (e.state === false) {
             this.unpause();
             if (e.advance) this.advance();
-          } else this.pause();
+          } else {
+            this.pause();
+          }
           break;
         case DriverEventEnum.manualAction:
           this.refresh();


### PR DESCRIPTION
Adds basic video handling, including listeners and behaviors for when in an active slideshow.

Missing: testing for some edge cases, pausing mid playback, etc.

Will need to style and center the video window.

Resolves #11