### PR TITLE
[#12] Add and unify fullscreen options

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,10 @@
 {
-  "cSpell.words": ["chakra", "Fullscreen", "IDBP", "quicktime", "tauri"]
+  "cSpell.words": [
+    "chakra",
+    "Dalle",
+    "Fullscreen",
+    "IDBP",
+    "quicktime",
+    "tauri"
+  ]
 }

--- a/src/package.json
+++ b/src/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "test-build": "npm run build && npx tauri dev",
+    "dev:tauri": "npm run test-build",
     "tauri": "tauri"
   },
   "dependencies": {

--- a/src/src-tauri/src/main.rs
+++ b/src/src-tauri/src/main.rs
@@ -2,13 +2,8 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use tauri::{ Menu, MenuItem, Submenu, CustomMenuItem };
-use tauri::Wry;
-use tauri_plugin_store::with_store;
-
-let stores = app.state::<StoreCollection<Wry>>();
-let path = PathBuf::from("app_data.bin");
-
-with_store(app_handle, stores, path, |store| store.insert("a".to_string(), json!("b")))
+// use tauri::Wry;
+// use std::path::PathBuf;
 
 #[derive(Clone, serde::Serialize)]
 struct Payload {
@@ -27,6 +22,12 @@ fn console_print(message: String) {
 	See example: https://doc.rust-lang.org/rust-by-example/attribute/cfg.html
 */
 fn main() {
+	/* Commented out as not all imports are complete for now, and is unused. */
+	// let stores = app.state::<StoreCollection<Wry>>();
+	// let path = PathBuf::from("app_data.bin");
+
+	// with_store(app_handle, stores, path, |store| store.insert("a".to_string(), json!("b")))
+
 	let file_menu = Submenu::new("File", Menu::new()
 		.add_item(CustomMenuItem::new("open_settings".to_string(), "Settings").accelerator("CommandOrControl+."))
 		.add_native_item(MenuItem::Separator)
@@ -34,7 +35,7 @@ fn main() {
 	);
 
 	let view_menu = Submenu::new("View", Menu::new()
-		.add_native_item(MenuItem::EnterFullScreen)
+		.add_item(CustomMenuItem::new("toggle_fullscreen".to_string(), "Fullscreen").accelerator("CommandOrControl+F"))
 	);
 
 	let window_menu_inner = Menu::new()
@@ -54,6 +55,9 @@ fn main() {
 			match event.menu_item_id() {
 				"open_settings" => {
 					event.window().emit("menu_event", Payload { message: "settings".to_string() }).unwrap();
+				},
+				"toggle_fullscreen" => {
+					event.window().emit("menu_event", Payload { message: "fullscreen".to_string() }).unwrap();
 				}
 				_ => {}
 			}

--- a/src/src/components/Home/Home.tsx
+++ b/src/src/components/Home/Home.tsx
@@ -55,8 +55,7 @@ export default function Home() {
       <VStack
         padding="10"
         borderRadius="4"
-        border="1px solid"
-        borderColor="orange.500"
+        boxShadow="5px 5px 14px 0px rgba(0, 0, 0, 0.4)"
         w="sm"
         h="md"
         zIndex={2}

--- a/src/src/components/Home/Home.tsx
+++ b/src/src/components/Home/Home.tsx
@@ -8,6 +8,8 @@ import useUIStateContext from 'src/hooks/useUiStateContext';
 import { Views } from 'src/utils/constants';
 import useSettingsContext from 'src/hooks/useSettingsContext';
 
+const DALLE_CAT = 'src/assets/Dalle_Cat.png';
+
 export default function Home() {
   const toast = useToast();
   const { setLibrary } = useLibraryContext();
@@ -41,6 +43,15 @@ export default function Home() {
       alignItems="center"
       justifyContent="center"
     >
+      <Image
+        src={DALLE_CAT}
+        position="fixed"
+        objectFit="cover"
+        w="full"
+        h="full"
+        opacity={0.3}
+        filter="blur(10px)"
+      />
       <VStack
         padding="10"
         borderRadius="4"
@@ -48,16 +59,17 @@ export default function Home() {
         borderColor="orange.500"
         w="sm"
         h="md"
+        zIndex={2}
       >
         <Box overflow="hidden" w="xs" borderRadius="full">
-          <Image src="src/assets/DallE_Cat.png" />
+          <Image src={DALLE_CAT} />
         </Box>
         <Text color="#EFDADA" mt="4" opacity="0.5">
           Drop files in, or click here to select
         </Text>
       </VStack>
 
-      <Dropzone onDrop={handleAddFiles} />
+      <Dropzone zIndex={3} onDrop={handleAddFiles} />
     </Box>
   );
 }

--- a/src/src/components/Show/ControlBar.tsx
+++ b/src/src/components/Show/ControlBar.tsx
@@ -7,6 +7,8 @@ import BackIcon from '@mui/icons-material/ArrowBack';
 import FirstIcon from '@mui/icons-material/FirstPage';
 import FolderIcon from '@mui/icons-material/Folder';
 import SettingsIcon from '@mui/icons-material/Settings';
+import FullscreenIcon from '@mui/icons-material/Fullscreen';
+import FullscreenExitIcon from '@mui/icons-material/FullscreenExit';
 
 import Dock from '../common/Dock';
 import Tooltip from '../common/Tooltip';
@@ -31,7 +33,7 @@ export default function ControlBar({
   navigateTo,
   onTogglePlay,
 }: Props) {
-  const { setView } = useUIStateContext();
+  const { setView, isFullscreen, toggleFullscreen } = useUIStateContext();
   const { setIsSettingsModalOpen } = useSettingsContext();
   const handlePlayStateChange = useCallback(
     (s: boolean) => () => {
@@ -105,6 +107,13 @@ export default function ControlBar({
               onClick={onRewind}
               aria-label="forward"
               icon={<FirstIcon />}
+            />
+          </Tooltip>
+          <Tooltip label="Toggle fullscreen" hasArrow placement="right">
+            <IconButton
+              onClick={toggleFullscreen}
+              aria-label="files"
+              icon={isFullscreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
             />
           </Tooltip>
           <Tooltip label="Return to file selection" hasArrow placement="right">

--- a/src/src/components/Show/ControlBar.tsx
+++ b/src/src/components/Show/ControlBar.tsx
@@ -76,12 +76,14 @@ export default function ControlBar({
           >
             {playing ? (
               <IconButton
+                variant="hollow"
                 onClick={handlePlayStateChange(false)}
                 aria-label="pause"
                 icon={<PauseIcon />}
               />
             ) : (
               <IconButton
+                variant="hollow"
                 onClick={handlePlayStateChange(true)}
                 aria-label="play"
                 icon={<PlayIcon />}
@@ -91,12 +93,14 @@ export default function ControlBar({
           <Tooltip label="Forward" hasArrow placement="right">
             <IconButton
               onClick={onForward}
+              variant="hollow"
               aria-label="forward"
               icon={<ForwardIcon />}
             />
           </Tooltip>
           <Tooltip label="Back" hasArrow placement="right">
             <IconButton
+              variant="hollow"
               onClick={onBack}
               aria-label="back"
               icon={<BackIcon />}
@@ -104,6 +108,7 @@ export default function ControlBar({
           </Tooltip>
           <Tooltip label="Rewind" hasArrow placement="right">
             <IconButton
+              variant="hollow"
               onClick={onRewind}
               aria-label="forward"
               icon={<FirstIcon />}
@@ -111,6 +116,7 @@ export default function ControlBar({
           </Tooltip>
           <Tooltip label="Toggle fullscreen" hasArrow placement="right">
             <IconButton
+              variant="hollow"
               onClick={toggleFullscreen}
               aria-label="files"
               icon={isFullscreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
@@ -118,6 +124,7 @@ export default function ControlBar({
           </Tooltip>
           <Tooltip label="Return to file selection" hasArrow placement="right">
             <IconButton
+              variant="hollow"
               onClick={handleBackToLoad}
               aria-label="files"
               icon={<FolderIcon />}
@@ -125,6 +132,7 @@ export default function ControlBar({
           </Tooltip>
           <Tooltip label="Settings" hasArrow placement="right">
             <IconButton
+              variant="hollow"
               onClick={onOpenSettings}
               aria-label="settings"
               icon={<SettingsIcon />}

--- a/src/src/main.tsx
+++ b/src/src/main.tsx
@@ -11,7 +11,7 @@ import SettingsProvider from './providers/SettingsProvider.tsx';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <ChakraProvider theme={theme}>
+    <ChakraProvider theme={theme} cssVarsRoot="body">
       <ColorModeProvider>
         <SettingsProvider>
           <LibraryProvider>

--- a/src/src/providers/UIStateProvider.tsx
+++ b/src/src/providers/UIStateProvider.tsx
@@ -1,7 +1,9 @@
-import React, { createContext, useState } from 'react';
+import React, { createContext, useEffect, useState } from 'react';
 import { AlertProps } from '@chakra-ui/react';
 
 import { Views } from 'src/utils/constants';
+import { fullscreen } from 'src/utils/tauriAdapter';
+import generalEventBus, { GeneralEventMessage } from 'src/utils/events/general';
 
 type AlertMessage = {
   message: string;
@@ -17,6 +19,8 @@ interface UIStateContextValues {
   setAlert: (alert: AlertState) => void;
   view: Views;
   setView: (v: Views) => void;
+  isFullscreen: boolean;
+  toggleFullscreen: () => void;
 }
 
 export const UIStateContext = createContext<UIStateContextValues>({
@@ -26,6 +30,8 @@ export const UIStateContext = createContext<UIStateContextValues>({
   setAlert: (_) => {},
   view: Views.home,
   setView: (_) => {},
+  isFullscreen: false,
+  toggleFullscreen: () => {},
 });
 
 interface ProviderProps {}
@@ -36,10 +42,39 @@ const UIStateProvider: React.FC<React.PropsWithChildren<ProviderProps>> = ({
   const [loading, setLoading] = useState(false);
   const [alert, setAlert] = useState<AlertState>(null);
   const [view, setView] = useState(Views.home);
+  const [isFullscreen, setFullscreen] = useState(false);
+
+  const toggleFullscreen = async () => {
+    const currentlyFullscreen = await fullscreen.isOn();
+    await fullscreen.set(!currentlyFullscreen);
+    setFullscreen(!currentlyFullscreen);
+  };
+
+  useEffect(() => {
+    const sub = generalEventBus.subscribe((e) => {
+      switch (e.message) {
+        case GeneralEventMessage.fullscreen:
+          toggleFullscreen();
+          break;
+        default:
+      }
+    });
+
+    return () => sub.unsubscribe();
+  }, []);
 
   return (
     <UIStateContext.Provider
-      value={{ loading, setLoading, alert, setAlert, view, setView }}
+      value={{
+        loading,
+        setLoading,
+        alert,
+        setAlert,
+        view,
+        setView,
+        isFullscreen,
+        toggleFullscreen,
+      }}
     >
       {children}
     </UIStateContext.Provider>

--- a/src/src/utils/events/general.ts
+++ b/src/src/utils/events/general.ts
@@ -9,6 +9,8 @@ export enum GeneralEventMessage {
   settings = 'settings',
   /** idb has been initialized */
   idbReady = 'idbReady',
+  /** Toggle fullscreen */
+  fullscreen = 'fullscreen',
 }
 
 export type GeneralEvent = {

--- a/src/src/utils/tauriAdapter.ts
+++ b/src/src/utils/tauriAdapter.ts
@@ -3,6 +3,8 @@ import { window as apiWindow, event } from '@tauri-apps/api';
 import debounce from 'lodash/debounce';
 import generalEventBus, { GeneralEventMessage } from './events/general';
 
+const IN_TAURI = !!window.__TAURI__;
+
 /** Sends a message to print into Tauri's console */
 export const tauriPrint = (message: string) =>
   invoke('console_print', { message });
@@ -14,8 +16,15 @@ export const tauriPrintDebounced = debounce(tauriPrint, 500, {
 
 export const fullscreen = {
   set: (fullscreen: boolean): Promise<void> =>
-    apiWindow.appWindow.setFullscreen(fullscreen),
-  isOn: () => apiWindow.appWindow.isFullscreen(),
+    IN_TAURI
+      ? apiWindow.appWindow.setFullscreen(fullscreen)
+      : fullscreen
+      ? document.documentElement.requestFullscreen()
+      : document.exitFullscreen(),
+  isOn: () =>
+    IN_TAURI
+      ? apiWindow.appWindow.isFullscreen()
+      : !!document.fullscreenElement,
 };
 
 type Payload = {

--- a/src/src/utils/theme.ts
+++ b/src/src/utils/theme.ts
@@ -1,4 +1,9 @@
-import { extendTheme, ComponentStyleConfig } from '@chakra-ui/react';
+import {
+  extendTheme,
+  defineStyle,
+  defineStyleConfig,
+  ComponentStyleConfig,
+} from '@chakra-ui/react';
 import { COLORS } from './constants';
 
 const VStack: ComponentStyleConfig = {
@@ -7,7 +12,24 @@ const VStack: ComponentStyleConfig = {
   },
 };
 
+const IconButton: ComponentStyleConfig = defineStyleConfig({
+  variants: {
+    hollow: {
+      background: 'none',
+      color: 'gray.200',
+    },
+  },
+  baseStyle: defineStyle({
+    background: 'unset',
+    color: 'gray.200',
+  }),
+});
+
 const theme = extendTheme({
+  config: {
+    initialColorMode: 'light',
+    useSystemColorMode: true,
+  },
   fonts: {
     body: 'Verdana, system-ui, sans-serif',
     heading: 'Georgia, serif',
@@ -25,6 +47,7 @@ const theme = extendTheme({
   },
   components: {
     VStack,
+    IconButton,
   },
 });
 


### PR DESCRIPTION
Adds fullscreening from menu and in-app, unifying them.

Also changes some styling around.

<img width="1017" alt="Screenshot 2024-06-28 at 12 11 24 AM" src="https://github.com/TestaDiMucca/Imageview/assets/28716303/b4dd9c85-d282-4e0b-b194-ecdf06bf6fb0">

Resolves #12